### PR TITLE
Changed coordinates to floating point

### DIFF
--- a/Prepare-For-Spine.lua
+++ b/Prepare-For-Spine.lua
@@ -152,19 +152,19 @@ function restoreVisibilities(layers, visibilityStates)
 end
 
 -----------------------------------------------[[ Main Execution ]]-----------------------------------------------
-local activeSprite = app.activeSprite
+local sprite = app.sprite
 
-if (activeSprite == nil) then
+if (sprite == nil) then
     -- If user has no active sprite selected in the UI
     app.alert("Please click the sprite you'd like to export")
     return
-elseif (activeSprite.filename == "") then
+elseif (sprite.filename == "") then
     -- If the user has created a sprite, but never saved it
     app.alert("Please save the current sprite before running this script")
     return
 end
 
-local flattenedLayers = getLayers(activeSprite, {})
+local flattenedLayers = getLayers(sprite, {})
 
 if (containsDuplicates(flattenedLayers)) then
     return
@@ -175,7 +175,7 @@ local visibilities = captureVisibilityStates(flattenedLayers)
 
 -- Saves each sprite layer as a separate .png under the 'images' subdirectory
 -- and write out the json file for importing into spine.
-captureLayers(flattenedLayers, activeSprite, visibilities)
+captureLayers(flattenedLayers, sprite, visibilities)
 
 -- Restore the layer's visibilities to how they were before
 restoreVisibilities(flattenedLayers, visibilities)

--- a/Prepare-For-Spine.lua
+++ b/Prepare-For-Spine.lua
@@ -115,7 +115,7 @@ function captureLayers(layers, sprite, visibilityStates)
             layer.isVisible = false
             local name = layer.name
             slotsJson[index] = string.format([[ { "name": "%s", "bone": "%s", "attachment": "%s" } ]], name, "root", name)
-            skinsJson[index] = string.format([[ "%s": { "%s": { "x": %d, "y": %d, "width": 1, "height": 1 } } ]], name, name, cel.bounds.width/2 + cel.position.x - sprite.bounds.width/2, sprite.bounds.height - cel.position.y - cel.bounds.height/2)
+            skinsJson[index] = string.format([[ "%s": { "%s": { "x": %.2f, "y": %.2f, "width": 1, "height": 1 } } ]], name, name, cel.bounds.width/2 + cel.position.x - sprite.bounds.width/2, sprite.bounds.height - cel.position.y - cel.bounds.height/2)
             index = index + 1
         end
     end


### PR DESCRIPTION
Changed json parsing to floating point because when using a decimal, we lose precision making the exported sprite shifted in many instances.